### PR TITLE
Support Python <3.12

### DIFF
--- a/dodcerts/bundle.py
+++ b/dodcerts/bundle.py
@@ -9,4 +9,4 @@ def where():
     Returns:
         the filepath of the DoD Certificate chain as a PEM bundle
     """
-    return os.getenv('DOD_CA_CERTS_PEM_PATH', files() / 'dod-ca-certs.pem')
+    return os.getenv('DOD_CA_CERTS_PEM_PATH', files('dodcerts') / 'dod-ca-certs.pem')


### PR DESCRIPTION
Using "files()" without an argument only works in Python 3.12. Adding "dodcerts" in there should support Python 3.9-3.11 and still avoid any DeprecationWarning. 

https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files shows files() was introduced in 3.9, and changing _package_ into an optional _anchor_ argument was introduced in 3.12.

I tried to build a conda environment with python 3.12 but couldn't get it to work with pandas 1.5.3. I also had trouble with gmpy2 when upgrading an environment.